### PR TITLE
feat: transform Object.defineProperty(module, 'exports', { get })

### DIFF
--- a/src/transformer/visitor/visit/visit-call-expression.ts
+++ b/src/transformer/visitor/visit/visit-call-expression.ts
@@ -16,13 +16,42 @@ import {walkThroughFillerNodes} from "../../util/walk-through-filler-nodes";
  * @returns
  */
 export function visitCallExpression({node, childContinuation, sourceFile, context}: BeforeVisitorOptions<TS.CallExpression>): TS.VisitResult<TS.Node> {
+	const {typescript, factory} = context;
+
+	if (node.expression.getText() === "Object.defineProperty") {
+		const args = node.arguments;
+		if (args.length === 3) {
+			const [obj, prop, descriptor] = args;
+			if (typescript.isIdentifier(obj) && obj.text === "module" &&
+					typescript.isStringLiteral(prop) && prop.text === "exports" &&
+					typescript.isObjectLiteralExpression(descriptor)) {
+				for (const element of descriptor.properties) {
+					if (!typescript.isPropertyAssignment(element)) {
+						continue;
+					}
+
+					const {name, initializer} = element;
+					if (!TS.isIdentifier(name) || !typescript.isIdentifier(initializer)) {
+						continue;
+					}
+
+					if (name.text === "get") {
+						context.markDefaultAsExported();
+						context.addTrailingStatements(factory.createExportAssignment(undefined, undefined, false,
+							factory.createCallExpression(initializer, [], [])));
+						return undefined;
+					}
+				}
+			}
+		}
+	}
+
 	if (context.onlyExports) {
 		return childContinuation(node);
 	}
 
 	// Check if the node represents a require(...) call.
 	const requireData = isRequireCall(node, sourceFile, context);
-	const {typescript, factory} = context;
 
 	// If it doesn't proceed without applying any transformations
 	if (!requireData.match) {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -994,3 +994,21 @@ test("Handles reassignments to imported bindings. #3", withTypeScript, (t, {type
 		`)
 	);
 });
+
+test("Converts 'Object.defineProperty(...)' syntax into an ExportAssignment", withTypeScript, (t, {typescript}) => {
+	const bundle = executeTransformer(
+		`
+		function foo () {}
+		Object.defineProperty(module, 'exports', { get: foo });
+	`,
+		{typescript}
+	);
+	const [file] = bundle.files;
+	t.deepEqual(
+		formatCode(file.text),
+		formatCode(`\
+		function foo () {}
+		export default foo();
+		`)
+	);
+});


### PR DESCRIPTION
So the ansi-styles package can be transformed to ESM.