### PR TITLE
Disable support for Typescript 5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"resolve": "^1.22.0"
 	},
 	"peerDependencies": {
-		"typescript": ">=3.2.x || >= 4.x"
+		"typescript": ">=3.2.x || ^4.x"
 	},
 	"exports": {
 		"import": "./dist/esm/index.js",


### PR DESCRIPTION
According to this package, it supports all future versions of Typescript, which means `npm` will usually install the very latest version.

Unfortunately, this package breaks when Typescript 5 is used.

This is a quick fix to make sure `npm` installs a version of Typescript that won't break the package.

Fixes #34